### PR TITLE
[1.19.2] Clean up XPHelper

### DIFF
--- a/src/main/java/net/lyof/sortilege/events/ModEvents.java
+++ b/src/main/java/net/lyof/sortilege/events/ModEvents.java
@@ -70,9 +70,10 @@ public class ModEvents {
         // Player got killed
         if (event.getEntity() instanceof Player player) {
             // Split the xp
-            int safe_xp = (int) Math.round(XPHelper.getTotalxp(player, server) * ConfigEntries.selfXPRatio);
-            int steal_xp = (int) Math.round(XPHelper.getTotalxp(player, server) * ConfigEntries.attackerXPRatio);
-            int drop_xp = (int) Math.round(XPHelper.getTotalxp(player, server) * ConfigEntries.dropXPRatio);
+            double total_xp = XPHelper.getTotalxp(player);
+            int safe_xp = (int) Math.round(total_xp * ConfigEntries.selfXPRatio);
+            int steal_xp = (int) Math.round(total_xp * ConfigEntries.attackerXPRatio);
+            int drop_xp = (int) Math.round(total_xp * ConfigEntries.dropXPRatio);
 
             // Save a part for respawn
             if (XPHelper.XP_SAVES.containsKey(player.getStringUUID()))

--- a/src/main/java/net/lyof/sortilege/events/ModEvents.java
+++ b/src/main/java/net/lyof/sortilege/events/ModEvents.java
@@ -106,7 +106,7 @@ public class ModEvents {
             }
 
             // Drop the last part
-            //XPHelper.dropxpPinata(player.getLevel(), player.getX(), player.getY(), player.getZ(), drop_xp);
+            player.skipDropExperience();
             ExperienceOrb.award(server, player.position(), drop_xp);
         }
 

--- a/src/main/java/net/lyof/sortilege/utils/XPHelper.java
+++ b/src/main/java/net/lyof/sortilege/utils/XPHelper.java
@@ -1,67 +1,29 @@
 package net.lyof.sortilege.utils;
 
-import net.lyof.sortilege.Sortilege;
-import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.Level;
-import net.minecraftforge.common.util.FakePlayerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class XPHelper {
     public static Map<String, Integer> XP_SAVES = new HashMap<>();
-    private static final Map<Integer, Integer> totalxpCache = new HashMap<>();
-
 
     public static boolean hasXP(Player player, int amount) {
-        float count = player.getXpNeededForNextLevel() * player.experienceProgress;
-        int i = 0;
-        while (count < amount) {
-            if (player.experienceLevel <= 0) {
-                player.experienceLevel += i;
-                return false;
-            }
-
-            i++;
-            player.experienceLevel -= 1;
-            count += player.getXpNeededForNextLevel();
-        }
-        player.experienceLevel += i;
-        return true;
+        return getTotalxp(player) >= amount;
     }
 
-    public static int getTotalxp(Player player, ServerLevel server) {
-        return getTotalxp(player.experienceLevel, player.experienceProgress, server);
-    }
-
-    public static int getTotalxp(int level, float progress, ServerLevel server) {
-        Player dummy = FakePlayerFactory.getMinecraft(server);
-        int total = 0;
-
-        if (totalxpCache.containsKey(level)) {
-            dummy.experienceLevel = level;
-            return (int) (totalxpCache.get(level) + dummy.getXpNeededForNextLevel() * progress);
-        }
+    public static int getTotalxp(Player player) {
+        int level = player.experienceLevel;
+        float progress = player.experienceProgress;
+        float total = 0;
 
         for (int i = 0; i <= level; i++) {
-            dummy.experienceLevel = i;
-            total += dummy.getXpNeededForNextLevel() * (i == level ? progress : 1);
+            player.experienceLevel = i;
+            total += player.getXpNeededForNextLevel() * (i == level ? progress : 1.0F);
         }
 
-        totalxpCache.put(level, total);
-        return total;
-    }
-
-    public static void dropxpPinata(Level world, double x, double y, double z, int amount) {
-        for (int i = 0; i < amount; i++) {
-            world.addFreshEntity(new ExperienceOrb(
-                    world,
-                    x,
-                    y,
-                    z,
-                    1));
-        }
+        // reset the player's level to what we started with
+        player.experienceLevel = level;
+        return Math.round(total);
     }
 }


### PR DESCRIPTION
This PR cleans up and deletes much of XPHelper's unnecessary functionality in favor of directly using the player's `totalExperience` field.