### PR TITLE
Fix Better Nether crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.20.1+build.10
 loader_version=0.15.11
 
 # Mod Properties
-mod_version=1.6.3
+mod_version=1.6.4
 maven_group=net.lyof.sortilege
 archives_base_name=Sortilege-1.20.1
 

--- a/src/main/java/net/lyof/sortilege/util/ItemHelper.java
+++ b/src/main/java/net/lyof/sortilege/util/ItemHelper.java
@@ -57,6 +57,8 @@ public class ItemHelper {
     }
 
     public static int getTotalEnchantSlots(ItemStack stack) {
+        if (ENCHLIMIT_CACHE == null) return 0;
+
         int l = getBaseEnchantSlots(stack);
         if (l >= 0)
             l = l + getExtraEnchantSlots(stack) + getCurseEnchantSlots(stack);


### PR DESCRIPTION
Fixes better nether crash by null checking the enchantment limit cache and returning 0 if so.

Having a value of 0 does not break Better Nether's logic, as this crash is simply caused by the cache not being loaded at early stages of the game, an alternative solution would be to load it earlier but it doesn't really matter much, as things work as intended.